### PR TITLE
Allow the backend to handle shutdown messages

### DIFF
--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -212,7 +212,8 @@ defmodule FLAME.Runner do
     end
   end
 
-  def handle_info({_ref, {:remote_shutdown, reason}}, state) do
+  def handle_info({_ref, {:remote_shutdown, reason}} = msg, state) do
+    maybe_backend_handle_info(state, msg)
     {:stop, {:shutdown, reason}, state}
   end
 


### PR DESCRIPTION
According to the [docs](https://hexdocs.pm/flame/FLAME.Backend.html#module-messaging), the `{ref, {:remote_shutdown, :idle}}` message is forwarded to the backend. That's not the case. This PR forwards `:remote_shutdown` messages to the backend.