### PR TITLE
Adds mounts to fly backend

### DIFF
--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -54,6 +54,7 @@ defmodule FLAME.FlyBackend do
              :cpu_kind,
              :cpus,
              :gpu_kind,
+             :mounts,
              :memory_mb,
              :image,
              :app,
@@ -73,6 +74,7 @@ defmodule FLAME.FlyBackend do
             cpus: nil,
             memory_mb: nil,
             gpu_kind: nil,
+            mounts: [],
             image: nil,
             services: [],
             app: nil,
@@ -86,7 +88,7 @@ defmodule FLAME.FlyBackend do
             runner_private_ip: nil,
             runner_node_name: nil
 
-  @valid_opts ~w(app image token host cpu_kind cpus memory_mb gpu_kind boot_timeout env terminator_sup log services)a
+  @valid_opts ~w(app image token host cpu_kind cpus mounts memory_mb gpu_kind boot_timeout env terminator_sup log services)a
 
   @impl true
   def init(opts) do
@@ -179,11 +181,12 @@ defmodule FLAME.FlyBackend do
             name: "#{state.app}-flame-#{rand_id(20)}",
             config: %{
               image: state.image,
+              mounts: state.mounts,
               guest: %{
                 cpu_kind: state.cpu_kind,
                 cpus: state.cpus,
                 memory_mb: state.memory_mb,
-                gpu_kind: state.gpu_kind
+                gpu_kind: state.gpu_kind,
               },
               auto_destroy: true,
               restart: %{policy: "no"},

--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -184,6 +184,7 @@ defmodule FLAME.FlyBackend do
               all_vols
               |> Enum.filter(fn vol ->
                 vol["attached_machine_id"] == nil
+                and vol["state"] == "created"
               end)
 
             volume_ids_by_name =

--- a/lib/flame/fly_backend/mounts.ex
+++ b/lib/flame/fly_backend/mounts.ex
@@ -1,8 +1,9 @@
 defmodule FLAME.FlyBackend.Mounts do
   @derive Jason.Encoder
   defstruct name: nil,
-            path: nil
-            # extend_threshold_percent: 0,
-            # add_size_gb: 0,
-            # size_gb_limit: 0
+            path: nil,
+            volume: nil,
+            extend_threshold_percent: 0,
+            add_size_gb: 0,
+            size_gb_limit: 0
 end

--- a/lib/flame/fly_backend/mounts.ex
+++ b/lib/flame/fly_backend/mounts.ex
@@ -1,0 +1,8 @@
+defmodule FLAME.FlyBackend.Mounts do
+  @derive Jason.Encoder
+  defstruct name: nil,
+            path: nil
+            # extend_threshold_percent: 0,
+            # add_size_gb: 0,
+            # size_gb_limit: 0
+end


### PR DESCRIPTION
I'm working on getting some elastic LLM inference set up using phoenix, fly, and FLAME and needed volumes attached to my flame workers so that I don't need to download an 8gb+ model on startup.

I added support for the `mounts` field in the machines api (https://fly.io/docs/machines/working-with-machines/)

Though it seems like fly has a bug where this isn't working right now. I keep getting 500s when passing in that argument. I made a thread on their forum to track it
https://community.fly.io/t/machine-api-returning-500-when-passing-in-mounts/17336