### PR TITLE
Fix pool supervisor fixed name

### DIFF
--- a/lib/flame/pool/supervisor.ex
+++ b/lib/flame/pool/supervisor.ex
@@ -2,7 +2,10 @@ defmodule FLAME.Pool.Supervisor do
   use Supervisor
 
   def start_link(opts) do
-    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+    name = Keyword.fetch!(opts, :name)
+    pool_sup = Module.concat(name, "PoolSup")
+
+    Supervisor.start_link(__MODULE__, opts, name: pool_sup)
   end
 
   def init(opts) do


### PR DESCRIPTION
This PR fixes a situation where the application tries to spawn multiple different flame pools, resulting in an already started error from `Flame.Pool.Supervisor`.