### PR TITLE
Fix Fly API docs link

### DIFF
--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -24,6 +24,8 @@ defmodule FLAME.FlyBackend do
 
     * `:cpu_kind` - The size of the runner CPU. Defaults to `"performance"`.
 
+    * `:gpu_kind` - The type of GPU reservation to make`.
+
     * `:cpus` - The number of runner CPUs. Defaults to  `System.schedulers_online()`
       for the number of cores of the running parent app.
 

--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -20,7 +20,7 @@ defmodule FLAME.FlyBackend do
   ```
 
   The following backend options are supported, and mirror the
-  (Fly.io machines create API)[https://fly.io/docs/machines/working-with-machines/]:
+  [Fly.io machines create API](https://fly.io/docs/machines/api/machines-resource/#machine-config-object-properties):
 
     * `:cpu_kind` - The size of the runner CPU. Defaults to `"performance"`.
 


### PR DESCRIPTION
Hey, I just noticed, that the Markdown the hyperlink to the Fly docs was not correctly formatted. The link also went to a 404 page so I tried to find a suitable replacement. Let me know if you want to link to a different URL. 

I also added the docs for the undocumented `gpu_kind` option

Cheers!