### PR TITLE
Add hotstart_threshold to flame.pool

### DIFF
--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -58,7 +58,8 @@ defmodule FLAME.Pool do
             on_grow_start: nil,
             on_grow_end: nil,
             on_shrink: nil,
-            async_boot_timer: nil
+            async_boot_timer: nil,
+            hotstart_threshold: 1
 
   def child_spec(opts) do
     %{
@@ -128,6 +129,10 @@ defmodule FLAME.Pool do
 
         * `:name` - The name of the pool
         * `:count` - The number of runners the pool is attempting to shrink to
+
+    * `:hotstart_threshold` - The percentage of pool utilisation before a new node is preemptively
+      added to the pool.
+      Should be a number 0 < n <= 1
   """
   def start_link(opts) do
     Keyword.validate!(opts, [
@@ -149,7 +154,8 @@ defmodule FLAME.Pool do
       :shutdown_timeout,
       :on_grow_start,
       :on_grow_end,
-      :on_shrink
+      :on_shrink,
+      :hotstart_threshold
     ])
 
     GenServer.start_link(__MODULE__, opts, name: Keyword.fetch!(opts, :name))
@@ -330,7 +336,8 @@ defmodule FLAME.Pool do
       on_grow_start: opts[:on_grow_start],
       on_grow_end: opts[:on_grow_end],
       on_shrink: opts[:on_shrink],
-      runner_opts: runner_opts
+      runner_opts: runner_opts,
+      hotstart_threshold: Keyword.get(opts, :hotstart_threshold, 1)
     }
 
     {:ok, boot_runners(state)}
@@ -452,10 +459,13 @@ defmodule FLAME.Pool do
   defp checkout_runner(%Pool{} = state, deadline, from, monitor_ref \\ nil) do
     min_runner = min_runner(state)
     runner_count = runner_count(state)
+    threshold = state.max_concurrency * state.hotstart_threshold
 
     cond do
       runner_count == 0 || !min_runner ||
-          (min_runner.count == state.max_concurrency && runner_count < state.max) ->
+        (min_runner.count == state.max_concurrency && runner_count < state.max) ||
+          (threshold > 1 && min_runner.count > threshold) ->
+        # if the threshold is less than 1 you would get a recursive creation of new nodes
         if map_size(state.pending_runners) > 0 || state.async_boot_timer do
           waiting_in(state, deadline, from)
         else


### PR DESCRIPTION
upon the concurrency exceeding the threshold a new node is added to the pool. 

This allows for pre-empting load and is intended for usecases where a cold-start is costly, such as for machine learning models

I'm not 100% on the implementation on this. Do we would want to spawn the new runner, but then do the cond case as usual? That way the waiting job goes into the exisiting runner, and the new runner can spin up.

Also the new runner will most likely become the new `min_runner` which means potentially not utilising the previous min runner to it's maximum potential. Would this be an issue?

related to https://github.com/phoenixframework/flame/issues/30