### PR TITLE
Remove errant backtick

### DIFF
--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -22,29 +22,29 @@ defmodule FLAME.FlyBackend do
   The following backend options are supported, and mirror the
   [Fly.io machines create API](https://fly.io/docs/machines/api/machines-resource/#machine-config-object-properties):
 
-    * `:cpu_kind` - The size of the runner CPU. Defaults to `"performance"`.
+  * `:cpu_kind` - The size of the runner CPU. Defaults to `"performance"`.
 
-    * `:gpu_kind` - The type of GPU reservation to make`.
+  * `:gpu_kind` - The type of GPU reservation to make.
 
-    * `:cpus` - The number of runner CPUs. Defaults to  `System.schedulers_online()`
-      for the number of cores of the running parent app.
+  * `:cpus` - The number of runner CPUs. Defaults to  `System.schedulers_online()`
+    for the number of cores of the running parent app.
 
-    * `:memory_mb` - The memory of the runner. Must be a 1024 multiple. Defaults to `4096`.
+  * `:memory_mb` - The memory of the runner. Must be a 1024 multiple. Defaults to `4096`.
 
-    * `:boot_timeout` - The boot timeout. Defaults to `30_000`.
+  * `:boot_timeout` - The boot timeout. Defaults to `30_000`.
 
-    * `:app` – The name of the otp app. Defaults to `System.get_env("FLY_APP_NAME")`,
+  * `:app` – The name of the otp app. Defaults to `System.get_env("FLY_APP_NAME")`,
 
-    * `:image` – The URL of the docker image to pass to the machines create endpoint.
-      Defaults to `System.get_env("FLY_IMAGE_REF")` which is the image of your running app.
+  * `:image` – The URL of the docker image to pass to the machines create endpoint.
+    Defaults to `System.get_env("FLY_IMAGE_REF")` which is the image of your running app.
 
-    * `:token` – The Fly API token. Defaults to `System.get_env("FLY_API_TOKEN")`.
+  * `:token` – The Fly API token. Defaults to `System.get_env("FLY_API_TOKEN")`.
 
-    * `:host` – The host of the Fly API. Defaults to `"https://api.machines.dev"`.
+  * `:host` – The host of the Fly API. Defaults to `"https://api.machines.dev"`.
 
-    * `:services` - The optional services to run on the machine. Defaults to `[]`.
+  * `:services` - The optional services to run on the machine. Defaults to `[]`.
 
-    * `:metadata` - The optional map of metadata to set for the machine. Defaults to `%{}`.
+  * `:metadata` - The optional map of metadata to set for the machine. Defaults to `%{}`.
 
   ## Environment Variables
 


### PR DESCRIPTION
There was an errant backtick on line 27 which was causing the docs output to fail to render the section about environment variables
Before

![image](https://github.com/phoenixframework/flame/assets/1583673/0018fc1f-108d-4477-bc4b-dfc179a73f94)

After

<img width="1057" alt="Screenshot 2024-05-27 at 8 08 13 AM" src="https://github.com/phoenixframework/flame/assets/1583673/84a0073d-2e68-4bc7-97e3-14d3b0b1a01b">

