### PR TITLE
feat: gigalixir support

### DIFF
--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -83,7 +83,7 @@ defmodule FLAME.FlyBackend do
   """
   @behaviour FLAME.Backend
 
-  alias FLAME.FlyBackend
+  alias FLAME.{FlyBackend, HttpClient}
 
   require Logger
 
@@ -237,7 +237,7 @@ defmodule FLAME.FlyBackend do
       with_elapsed_ms(fn ->
         flame_node_base = "#{state.app}-flame-#{rand_id(20)}"
 
-        http_post!("#{state.host}/v1/apps/#{state.app}/machines",
+        HttpClient.post!("#{state.host}/v1/apps/#{state.app}/machines",
           content_type: "application/json",
           headers: [
             {"Content-Type", "application/json"},
@@ -315,80 +315,5 @@ defmodule FLAME.FlyBackend do
     |> Base.encode64(padding: false)
     |> binary_part(0, len)
     |> String.replace(~r/[^a-zA-Z0-9]/, "")
-  end
-
-  defp http_post!(url, opts) do
-    Keyword.validate!(opts, [:headers, :body, :connect_timeout, :content_type])
-
-    headers =
-      for {field, val} <- Keyword.fetch!(opts, :headers),
-          do: {String.to_charlist(field), val}
-
-    body = Keyword.fetch!(opts, :body)
-    connect_timeout = Keyword.fetch!(opts, :connect_timeout)
-    content_type = Keyword.fetch!(opts, :content_type)
-
-    http_opts = [
-      ssl:
-        [
-          verify: :verify_peer,
-          depth: 2,
-          customize_hostname_check: [
-            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-          ]
-        ] ++ cacerts_options(),
-      connect_timeout: connect_timeout
-    ]
-
-    case :httpc.request(:post, {url, headers, ~c"#{content_type}", body}, http_opts, []) do
-      {:ok, {{_, 200, _}, _, response_body}} ->
-        Jason.decode!(response_body)
-
-      {:ok, {{_, status, reason}, _, resp_body}} ->
-        raise "failed POST #{url} with #{inspect(status)} (#{inspect(reason)}): #{inspect(resp_body)} #{inspect(headers)}"
-
-      {:error, reason} ->
-        raise "failed POST #{url} with #{inspect(reason)} #{inspect(headers)}"
-    end
-  end
-
-  defp cacerts_options do
-    cond do
-      certs = otp_cacerts() ->
-        [cacerts: certs]
-
-      Application.spec(:castore, :vsn) ->
-        [cacertfile: Application.app_dir(:castore, "priv/cacerts.pem")]
-
-      true ->
-        IO.warn("""
-        No certificate trust store was found.
-
-        A certificate trust store is required in
-        order to download locales for your configuration.
-        Since elixir_make could not detect a system
-        installed certificate trust store one of the
-        following actions may be taken:
-
-        1. Use OTP 25+ on an OS that has built-in certificate
-           trust store.
-
-        2. Install the hex package `castore`. It will
-           be automatically detected after recompilation.
-
-        """)
-
-        []
-    end
-  end
-
-  if System.otp_release() >= "25" do
-    defp otp_cacerts do
-      :public_key.cacerts_get()
-    rescue
-      _ -> nil
-    end
-  else
-    defp otp_cacerts, do: nil
   end
 end

--- a/lib/flame/gigalixir_backend.ex
+++ b/lib/flame/gigalixir_backend.ex
@@ -12,7 +12,7 @@ defmodule FLAME.GigalixirBackend do
       
     * `:boot_timeout` - The boot timeout. Defaults to `60_000` (60 seconds).
 
-    * `:max_runtime` - The maximum runtime of the runner in seconds. Defaults to `300` (5 minutes).
+    * `:max_runtime` - The maximum runtime of the runner in seconds.
 
     * `:app` – The name of the Gigalixir app. Defaults to `System.get_env("GIGALIXIR__APP_NAME")`,
 
@@ -79,7 +79,6 @@ defmodule FLAME.GigalixirBackend do
       token: System.get_env("GIGALIXIR__APP_KEY"),
       host: "https://api.gigalixir.com",
       boot_timeout: 60_000,
-      max_runtime: 300,
       runner_node_basename: node_base,
       log: Keyword.get(conf, :log, false)
     }

--- a/lib/flame/gigalixir_backend.ex
+++ b/lib/flame/gigalixir_backend.ex
@@ -1,0 +1,210 @@
+defmodule FLAME.GigalixirBackend do
+  @moduledoc """
+  The `FLAME.Backend` using [Gigalixir](https://gigalixir.com) machines.
+
+  The only required configuration is telling FLAME to use the
+  `FLAME.GigalixirBackend` by default.
+
+  The following backend options are supported:
+
+    * `:size` - The size of the runner. Defaults to the application's size.
+      Minimum is `0.2`, which represent 200MiB of memory and 0.2 CPU shares.
+      
+    * `:boot_timeout` - The boot timeout. Defaults to `60_000` (60 seconds).
+
+    * `:max_runtime` - The maximum runtime of the runner in seconds. Defaults to `300` (5 minutes).
+
+    * `:app` – The name of the Gigalixir app. Defaults to `System.get_env("GIGALIXIR__APP_NAME")`,
+
+    * `:token` – The application's API token. Defaults to `System.get_env("GIGALIXIR__APP_KEY")`.
+
+    * `:host` – The host of the Gigalixir API. Defaults to `"https://api.gigalixir.com"`.
+  """
+  @behaviour FLAME.Backend
+
+  alias FLAME.{GigalixirBackend, HttpClient}
+
+  require Logger
+
+  @derive {Inspect,
+           only: [
+             :host,
+             :size,
+             :app,
+             :local_ip,
+             :remote_terminator_pid,
+             :runner_node_basename,
+             :runner_instance_id,
+             :runner_private_ip,
+             :runner_node_name,
+             :boot_timeout,
+             :max_runtime
+           ]}
+  defstruct host: nil,
+            local_ip: nil,
+            env: %{},
+            size: nil,
+            app: nil,
+            token: nil,
+            boot_timeout: nil,
+            max_runtime: nil,
+            remote_terminator_pid: nil,
+            parent_ref: nil,
+            runner_node_basename: nil,
+            runner_instance_id: nil,
+            runner_private_ip: nil,
+            runner_node_name: nil,
+            log: nil
+
+  @valid_opts [
+    :app,
+    :token,
+    :host,
+    :size,
+    :boot_timeout,
+    :max_runtime,
+    :env,
+    :terminator_sup,
+    :log
+  ]
+
+  @impl true
+  def init(opts) do
+    conf = Application.get_env(:flame, __MODULE__) || []
+    [node_base, _instance_name] = node() |> to_string() |> String.split("@")
+    ip = System.get_env("GIGALIXIR__REPLICA_IP")
+
+    default = %GigalixirBackend{
+      app: System.get_env("GIGALIXIR__APP_NAME"),
+      token: System.get_env("GIGALIXIR__APP_KEY"),
+      host: "https://api.gigalixir.com",
+      boot_timeout: 60_000,
+      max_runtime: 300,
+      runner_node_basename: node_base,
+      log: Keyword.get(conf, :log, false)
+    }
+
+    provided_opts =
+      conf
+      |> Keyword.merge(opts)
+      |> Keyword.validate!(@valid_opts)
+
+    state = Map.merge(default, Map.new(provided_opts))
+
+    for key <- [:token, :host, :app] do
+      unless Map.get(state, key) do
+        raise ArgumentError, "missing :#{key} config for #{inspect(__MODULE__)}"
+      end
+    end
+
+    parent_ref = make_ref()
+
+    encoded_parent =
+      parent_ref
+      |> FLAME.Parent.new(self(), __MODULE__, "GIGALIXIR__REPLICA_IP")
+      |> FLAME.Parent.encode()
+
+    new_env =
+      Map.merge(
+        %{PHX_SERVER: "false", FLAME_PARENT: encoded_parent},
+        state.env
+      )
+
+    new_state =
+      %GigalixirBackend{state | env: new_env, parent_ref: parent_ref, local_ip: ip}
+
+    {:ok, new_state}
+  end
+
+  @impl true
+  # TODO explore spawn_request
+  def remote_spawn_monitor(%GigalixirBackend{} = state, term) do
+    case term do
+      func when is_function(func, 0) ->
+        {pid, ref} = Node.spawn_monitor(state.runner_node_name, func)
+        {:ok, {pid, ref}}
+
+      {mod, fun, args} when is_atom(mod) and is_atom(fun) and is_list(args) ->
+        {pid, ref} = Node.spawn_monitor(state.runner_node_name, mod, fun, args)
+        {:ok, {pid, ref}}
+
+      other ->
+        raise ArgumentError,
+              "expected a null arity function or {mod, func, args}. Got: #{inspect(other)}"
+    end
+  end
+
+  @impl true
+  def system_shutdown do
+    System.stop()
+  end
+
+  def with_elapsed_ms(func) when is_function(func, 0) do
+    {micro, result} = :timer.tc(func)
+    {result, div(micro, 1000)}
+  end
+
+  @impl true
+  def remote_boot(%GigalixirBackend{parent_ref: parent_ref} = state) do
+    {resp, req_connect_time} =
+      with_elapsed_ms(fn ->
+        HttpClient.post!("#{state.host}/api/apps/#{state.app}/flame",
+          content_type: "application/json",
+          headers: [
+            {"Content-Type", "application/json"},
+            {"Authorization", basic_auth(state.app, state.token)}
+          ],
+          connect_timeout: state.boot_timeout,
+          body: Jason.encode!(flame_params(state))
+        )
+      end)
+
+    if state.log,
+      do:
+        Logger.log(
+          state.log,
+          "#{inspect(__MODULE__)} #{inspect(node())} FLAME create #{req_connect_time}ms"
+        )
+
+    remaining_connect_window = state.boot_timeout - req_connect_time
+
+    case resp do
+      %{"instance_id" => instance_id, "private_ip" => ip} ->
+        new_state = %GigalixirBackend{
+          state
+          | runner_instance_id: instance_id,
+            runner_private_ip: ip,
+            runner_node_name: :"#{state.runner_node_basename}@#{ip}"
+        }
+
+        remote_terminator_pid =
+          receive do
+            {^parent_ref, {:remote_up, remote_terminator_pid}} ->
+              remote_terminator_pid
+          after
+            remaining_connect_window ->
+              Logger.error("failed to connect to gigalixir FLAME within #{state.boot_timeout}ms")
+              exit(:timeout)
+          end
+
+        new_state = %GigalixirBackend{new_state | remote_terminator_pid: remote_terminator_pid}
+        {:ok, remote_terminator_pid, new_state}
+
+      other ->
+        {:error, other}
+    end
+  end
+
+  defp flame_params(state) do
+    %{
+      env: state.env,
+      max_runtime: state.max_runtime,
+      size: state.size
+    }
+    |> Map.filter(fn {_k, v} -> v end)
+  end
+
+  defp basic_auth(username, password) do
+    "Basic #{Base.encode64("#{username}:#{password}")}"
+  end
+end

--- a/lib/flame/http_client.ex
+++ b/lib/flame/http_client.ex
@@ -23,10 +23,10 @@ defmodule FLAME.HttpClient do
     ]
 
     case :httpc.request(:post, {url, headers, ~c"#{content_type}", body}, http_opts, []) do
-      {:ok, {{_, 201, _}, _, response_body}} ->
+      {:ok, {{_, 200, _}, _, response_body}} ->
         Jason.decode!(response_body)
 
-      {:ok, {{_, 200, _}, _, response_body}} ->
+      {:ok, {{_, 201, _}, _, response_body}} ->
         Jason.decode!(response_body)
 
       {:ok, {{_, status, reason}, _, resp_body}} ->

--- a/lib/flame/http_client.ex
+++ b/lib/flame/http_client.ex
@@ -1,0 +1,76 @@
+defmodule FLAME.HttpClient do
+  def post!(url, opts) do
+    Keyword.validate!(opts, [:headers, :body, :connect_timeout, :content_type])
+
+    headers =
+      for {field, val} <- Keyword.fetch!(opts, :headers),
+          do: {String.to_charlist(field), val}
+
+    body = Keyword.fetch!(opts, :body)
+    connect_timeout = Keyword.fetch!(opts, :connect_timeout)
+    content_type = Keyword.fetch!(opts, :content_type)
+
+    http_opts = [
+      ssl:
+        [
+          verify: :verify_peer,
+          depth: 2,
+          customize_hostname_check: [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ]
+        ] ++ cacerts_options(),
+      connect_timeout: connect_timeout
+    ]
+
+    case :httpc.request(:post, {url, headers, ~c"#{content_type}", body}, http_opts, []) do
+      {:ok, {{_, 200, _}, _, response_body}} ->
+        Jason.decode!(response_body)
+
+      {:ok, {{_, status, reason}, _, resp_body}} ->
+        raise "failed POST #{url} with #{inspect(status)} (#{inspect(reason)}): #{inspect(resp_body)} #{inspect(headers)}"
+
+      {:error, reason} ->
+        raise "failed POST #{url} with #{inspect(reason)} #{inspect(headers)}"
+    end
+  end
+
+  defp cacerts_options do
+    cond do
+      certs = otp_cacerts() ->
+        [cacerts: certs]
+
+      Application.spec(:castore, :vsn) ->
+        [cacertfile: Application.app_dir(:castore, "priv/cacerts.pem")]
+
+      true ->
+        IO.warn("""
+        No certificate trust store was found.
+
+        A certificate trust store is required in
+        order to download locales for your configuration.
+        Since elixir_make could not detect a system
+        installed certificate trust store one of the
+        following actions may be taken:
+
+        1. Use OTP 25+ on an OS that has built-in certificate
+           trust store.
+
+        2. Install the hex package `castore`. It will
+           be automatically detected after recompilation.
+
+        """)
+
+        []
+    end
+  end
+
+  if System.otp_release() >= "25" do
+    defp otp_cacerts do
+      :public_key.cacerts_get()
+    rescue
+      _ -> nil
+    end
+  else
+    defp otp_cacerts, do: nil
+  end
+end

--- a/lib/flame/http_client.ex
+++ b/lib/flame/http_client.ex
@@ -23,6 +23,9 @@ defmodule FLAME.HttpClient do
     ]
 
     case :httpc.request(:post, {url, headers, ~c"#{content_type}", body}, http_opts, []) do
+      {:ok, {{_, 201, _}, _, response_body}} ->
+        Jason.decode!(response_body)
+
       {:ok, {{_, 200, _}, _, response_body}} ->
         Jason.decode!(response_body)
 

--- a/test/gigalixir_backend_test.exs
+++ b/test/gigalixir_backend_test.exs
@@ -1,0 +1,70 @@
+defmodule FLAME.GigalixirBackendTest do
+  use ExUnit.Case, async: false
+
+  alias FLAME.{Runner, GigalixirBackend}
+
+  def new({backend, opts}) do
+    Runner.new(backend: {backend, Keyword.merge([terminator_sup: __MODULE__], opts)})
+  end
+
+  setup do
+    Application.delete_env(:flame, :backend)
+    Application.delete_env(:flame, GigalixirBackend)
+  end
+
+  test "explicit backend" do
+    assert_raise ArgumentError, ~r/missing :token/, fn ->
+      new({GigalixirBackend, []})
+    end
+
+    assert_raise ArgumentError, ~r/missing :app/, fn ->
+      new({GigalixirBackend, token: "123"})
+    end
+
+    assert_raise ArgumentError, ~r/missing :app/, fn ->
+      new({GigalixirBackend, token: "123"})
+    end
+
+    assert new({GigalixirBackend, token: "123", app: "app"})
+  end
+
+  test "extended opts" do
+    opts = [
+      token: "123",
+      app: "app",
+      host: "foo.local",
+      env: %{one: 1},
+      size: 1.0,
+      max_runtime: 45
+    ]
+
+    runner = new({GigalixirBackend, opts})
+    assert {:ok, init} = runner.backend_init
+    assert init.host == "foo.local"
+    assert init.size == 1.0
+    assert init.max_runtime == 45
+
+    assert %{
+             one: 1,
+             FLAME_PARENT: _,
+             PHX_SERVER: "false"
+           } = init.env
+  end
+
+  test "global configured backend" do
+    assert_raise ArgumentError, ~r/missing :token/, fn ->
+      Application.put_env(:flame, FLAME.GigalixirBackend, [])
+      Runner.new(backend: FLAME.GigalixirBackend)
+    end
+
+    assert_raise ArgumentError, ~r/missing :app/, fn ->
+      Application.put_env(:flame, FLAME.GigalixirBackend, token: "123")
+      Runner.new(backend: FLAME.GigalixirBackend)
+    end
+
+    Application.put_env(:flame, :backend, FLAME.GigalixirBackend)
+    Application.put_env(:flame, FLAME.GigalixirBackend, token: "123", app: "app")
+
+    assert Runner.new(backend: FLAME.GigalixirBackend)
+  end
+end


### PR DESCRIPTION
Adds a backend for [Gigalixir](https://gigalixir.com).

Includes a small refactor to move the http client methods out of the fly backend for reuse.