### PR TITLE
Pass :remote_shutdown messages to the backend

### DIFF
--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -195,20 +195,20 @@ defmodule FLAME.Runner do
             end
 
           %{} ->
-            {:noreply, maybe_backend_handle_info(state, msg)}
+            {:noreply, maybe_backend_handle_info(msg, state)}
         end
     end
   end
 
-  def handle_info({_ref, {:remote_shutdown, reason}}, state) do
-    {:stop, {:shutdown, reason}, state}
+  def handle_info({_ref, {:remote_shutdown, reason}} = msg, state) do
+    {:stop, {:shutdown, reason}, maybe_backend_handle_info(msg, state)}
   end
 
   def handle_info(msg, state) do
-    {:noreply, maybe_backend_handle_info(state, msg)}
+    {:noreply, maybe_backend_handle_info(msg, state)}
   end
 
-  defp maybe_backend_handle_info(state, msg) do
+  defp maybe_backend_handle_info(msg, state) do
     %Runner{backend: backend} = state.runner
 
     if function_exported?(backend, :handle_info, 2) do

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -219,6 +219,7 @@ defmodule FLAME.RunnerTest do
     test "with time" do
       timeout = 500
       {:ok, runner} = mock_successful_runner(1, idle_shutdown_after: timeout)
+      expect(MockBackend, :handle_info, fn {_ref, {:remote_shutdown, :idle}}, state -> {:noreply, state} end)
 
       Process.unlink(runner)
       Process.monitor(runner)
@@ -228,6 +229,8 @@ defmodule FLAME.RunnerTest do
       assert_receive {:DOWN, _ref, :process, ^runner, _}
 
       {:ok, runner} = mock_successful_runner(2, idle_shutdown_after: timeout)
+      expect(MockBackend, :handle_info, fn {_ref, {:remote_shutdown, :idle}}, state -> {:noreply, state} end)
+
       Process.unlink(runner)
       Process.monitor(runner)
       assert Runner.remote_boot(runner, nil) == :ok
@@ -241,6 +244,7 @@ defmodule FLAME.RunnerTest do
       timeout = 500
       idle_after = {timeout, fn -> Agent.get(agent, & &1) end}
       {:ok, runner} = mock_successful_runner(1, idle_shutdown_after: idle_after)
+      expect(MockBackend, :handle_info, fn {_ref, {:remote_shutdown, :idle}}, state -> {:noreply, state} end)
 
       Process.unlink(runner)
       Process.monitor(runner)


### PR DESCRIPTION
Based on the documentation, I was expecting my `FLAME.Backend` implementation to be able to receive the `{:remote_shutdown, reason}` message so it could do some cleanup, but they were not being passed to my `handle_info` callback. This remediates that problem.

While I was in there, I got stumped the argument order of `maybe_backend_handle_info` being switched from the order of `handle_info` arguments, so I swapped them to be consistent.