### PR TITLE
Ensure trackables occupy slots in the runner's concurrency pool.

### DIFF
--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -132,12 +132,12 @@ defmodule FLAME.Runner do
       end)
 
     case result do
-      {:ok, value} ->
-        :ok = checkin(runner_pid, ref)
-        value
+      {:ok, {value, trackable_pids}} ->
+        :ok = checkin(runner_pid, ref, trackable_pids)
+        {value, trackable_pids}
 
       {kind, reason} ->
-        :ok = checkin(runner_pid, ref)
+        :ok = checkin(runner_pid, ref, [])
 
         case kind do
           :exit -> exit(reason)
@@ -151,8 +151,8 @@ defmodule FLAME.Runner do
     GenServer.call(runner_pid, :checkout)
   end
 
-  defp checkin(runner_pid, ref) do
-    GenServer.call(runner_pid, {:checkin, ref})
+  defp checkin(runner_pid, ref, trackable_pids) do
+    GenServer.call(runner_pid, {:checkin, ref, trackable_pids})
   end
 
   @impl true
@@ -253,8 +253,6 @@ defmodule FLAME.Runner do
   end
 
   def handle_call(:checkout, {from_pid, _tag}, state) do
-    ref = Process.monitor(from_pid)
-
     state =
       case maybe_diff_code_paths(state) do
         {new_state, nil} ->
@@ -270,12 +268,20 @@ defmodule FLAME.Runner do
           new_state
       end
 
-    {:reply, {ref, state.runner, state.backend_state}, put_checkout(state, from_pid, ref)}
+    {new_state, ref} = put_checkout(state, from_pid)
+    {:reply, {ref, new_state.runner, new_state.backend_state}, new_state}
   end
 
-  def handle_call({:checkin, ref}, _from, state) do
+  def handle_call({:checkin, ref, trackable_pids}, _from, state) do
     Process.demonitor(ref, [:flush])
-    {:reply, :ok, drop_checkout(state, ref)}
+
+    new_state =
+      Enum.reduce(trackable_pids, state, fn pid, acc ->
+        {acc, _ref} = put_checkout(acc, pid)
+        acc
+      end)
+
+    {:reply, :ok, drop_checkout(new_state, ref)}
   end
 
   def handle_call({:remote_boot, base_sync_stream, _timeout}, _from, state) do
@@ -301,7 +307,7 @@ defmodule FLAME.Runner do
                 terminator: term
               } = new_runner
 
-              :ok =
+              {:ok, _} =
                 remote_call!(runner, new_backend_state, runner.boot_timeout, false, fn ->
                   # ensure app is fully started if parent connects before up
                   if otp_app, do: {:ok, _} = Application.ensure_all_started(otp_app)
@@ -407,8 +413,9 @@ defmodule FLAME.Runner do
     result
   end
 
-  defp put_checkout(state, from_pid, ref) when is_pid(from_pid) do
-    %{state | checkouts: Map.put(state.checkouts, ref, from_pid)}
+  defp put_checkout(state, from_pid) when is_pid(from_pid) do
+    ref = Process.monitor(from_pid)
+    {%{state | checkouts: Map.put(state.checkouts, ref, from_pid)}, ref}
   end
 
   defp drop_checkout(state, ref) when is_reference(ref) do
@@ -463,9 +470,9 @@ defmodule FLAME.Runner do
         if track_resources? do
           {result, pids} = FLAME.track_resources(result, [], node(remote_pid))
           send(remote_pid, {parent_ref, pids})
-          {:ok, result}
+          {:ok, {result, pids}}
         else
-          {:ok, result}
+          {:ok, {result, []}}
         end
 
       {:DOWN, ^remote_monitor_ref, :process, ^remote_pid, reason} ->

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -104,7 +104,7 @@ defmodule FLAME.RunnerTest do
       )
 
     assert Runner.remote_boot(runner, nil) == :ok
-    assert Runner.call(runner, self(), fn -> :works end) == :works
+    assert Runner.call(runner, self(), fn -> :works end) == {:works, []}
     assert_receive :stopped
   end
 
@@ -113,9 +113,9 @@ defmodule FLAME.RunnerTest do
 
     assert Runner.remote_boot(runner, nil) == :ok
     assert Runner.remote_boot(runner, nil) == {:error, :already_booted}
-    assert Runner.call(runner, self(), fn -> :works end) == :works
+    assert Runner.call(runner, self(), fn -> :works end) == {:works, []}
     refute_receive :stopped
-    assert Runner.call(runner, self(), fn -> :still_works end) == :still_works
+    assert Runner.call(runner, self(), fn -> :still_works end) == {:still_works, []}
     ref = Process.monitor(runner)
     assert Runner.shutdown(runner) == :ok
     assert_receive :stopped
@@ -169,7 +169,7 @@ defmodule FLAME.RunnerTest do
       assert {:exit, {%RuntimeError{message: "boom"}, _}} = error
       refute_receive :stopped
       refute_receive {:DOWN, _ref, :process, ^runner, _}
-      assert Runner.call(runner, self(), fn -> :works end) == :works
+      assert Runner.call(runner, self(), fn -> :works end) == {:works, []}
       assert Runner.shutdown(runner) == :ok
     end
   end
@@ -210,7 +210,7 @@ defmodule FLAME.RunnerTest do
 
       refute_receive :stopped
       refute_receive {:DOWN, _ref, :process, ^runner, _}
-      assert Runner.call(runner, self(), fn -> :works end, timeout: 1234) == :works
+      assert Runner.call(runner, self(), fn -> :works end, timeout: 1234) == {:works, []}
       assert Runner.shutdown(runner) == :ok
     end
   end
@@ -231,7 +231,7 @@ defmodule FLAME.RunnerTest do
       Process.unlink(runner)
       Process.monitor(runner)
       assert Runner.remote_boot(runner, nil) == :ok
-      assert Runner.call(runner, self(), fn -> :works end) == :works
+      assert Runner.call(runner, self(), fn -> :works end) == {:works, []}
       assert_receive :stopped, timeout * 2
       assert_receive {:DOWN, _ref, :process, ^runner, _}
     end
@@ -264,7 +264,7 @@ defmodule FLAME.RunnerTest do
 
       Process.monitor(runner)
       assert Runner.remote_boot(runner, stream) == :ok
-      assert Runner.call(runner, self(), fn -> :works end, timeout: 1234) == :works
+      assert Runner.call(runner, self(), fn -> :works end, timeout: 1234) == {:works, []}
       assert Runner.shutdown(runner) == :ok
       # called on remote boot
       assert_receive {CodeSyncMock, {_mock, :extract}}
@@ -278,7 +278,7 @@ defmodule FLAME.RunnerTest do
 
       Process.monitor(runner)
       assert Runner.remote_boot(runner, nil) == :ok
-      assert Runner.call(runner, self(), fn -> :works end, timeout: 1234) == :works
+      assert Runner.call(runner, self(), fn -> :works end, timeout: 1234) == {:works, []}
       assert Runner.shutdown(runner) == :ok
       refute_receive {CodeSyncMock, _}
     end


### PR DESCRIPTION
*Note*: this allows a single caller checkout (FLAME.call) to return multiple trackables that exceed the runners max_concurrency limits. This is intentional and concurrency limits will be properly tracked and freed as the trackables go down and their checkouts are released.