### PR TITLE
fix doc code snippets

### DIFF
--- a/lib/flame.ex
+++ b/lib/flame.ex
@@ -26,7 +26,7 @@ defmodule FLAME do
   features, entire function closures, including any state they close over, can be sent
   and executed on a remote node:
 
-      def resize_video_quality(%Video{} = video) do
+      def resize_video_quality(%Video{} = vid) do
         FLAME.call(MyApp.FFMpegRunner, fn ->
           path = "#{vid.id}_720p.mp4"
           System.cmd("ffmpeg", ~w(-i #{vid.url} -s 720x480 -c:a copy #{path}))
@@ -60,7 +60,7 @@ defmodule FLAME do
       children = [
         ...,
         {FLAME.Pool,
-         name: App.FFMpegRunner,
+         name: MyApp.FFMpegRunner,
          min: 0,
          max: 10,
          max_concurrency: 5,
@@ -75,7 +75,7 @@ defmodule FLAME do
 
   Calling a pool is as simple as passing its name to the FLAME functions:
 
-      FLAME.call(App.FFMpegRunner, fn -> :operation1 end)
+      FLAME.call(MyApp.FFMpegRunner, fn -> :operation1 end)
 
   You'll also often want to enable or disable other application services based on whether
   your application is being started as child FLAME runner or being run directly.


### PR DESCRIPTION
Minor changes to documentation

1. argument was bound to video but used in body as vid, also matches naming in previous example.
2. changed App to MyApp to make it more coherent.  `Thumbs`-app name have been left under [Deployment Considerations](https://github.com/phoenixframework/flame/blob/main/lib/flame.ex#L88-L114) as that is more concrete-example.
