### PR TITLE
Add shields for docs and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/phoenixframework/flame/elixir.yml)](https://github.com/phoenixframework/flame/actions/workflows/elixir.yml) [![Hex.pm](https://img.shields.io/hexpm/v/flame.svg)](https://hex.pm/packages/flame) [![Documentation](https://img.shields.io/badge/documentation-gray)](https://hexdocs.pm/flame)
+
 Imagine if we could auto scale simply by wrapping any existing app code in a function and have that block of code run in a temporary copy of the app.
 
 Enter the FLAME pattern.


### PR DESCRIPTION
I copied the setup from the Phoenix repo, though the flame README is a little different. I hope the shields at the top are still helpful for those navigating here.

I wasn't sure if leaving these out was a deliberate style choice, but I personally find them extremely useful. The github repo often pops up first and it's not trivial to get the docs up quickly. (Maybe my tooling needs improving 😉) 

Happy for this to be closed if you'd rather not have the badges up. 