### PR TITLE
Set the Runner `:timeout` option to the maximum between itself and the `:boot_timeout`

### DIFF
--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -363,6 +363,9 @@ defmodule FLAME.Runner do
         other when other in [{:ok, nil}, :error] -> {30_000, fn -> true end}
       end
 
+    timeout = opts[:timeout] || 30_000
+    boot_timeout = opts[:boot_timeout] || 30_000
+
     runner =
       %Runner{
         status: :awaiting_boot,
@@ -370,8 +373,8 @@ defmodule FLAME.Runner do
         backend_init: :pending,
         log: Keyword.get(opts, :log, false),
         single_use: Keyword.get(opts, :single_use, false),
-        timeout: opts[:timeout] || 30_000,
-        boot_timeout: opts[:boot_timeout] || 30_000,
+        timeout: max(timeout, boot_timeout),
+        boot_timeout: boot_timeout,
         shutdown_timeout: opts[:shutdown_timeout] || 30_000,
         idle_shutdown_after: idle_shutdown_after_ms,
         idle_shutdown_check: idle_check,


### PR DESCRIPTION
Currently, the `:timeout` and `:boot_timeout` are separate options - however, when running something that has a long `:boot_timeout` set, you must know to set the `:timeout` option to the same time (or longer), otherwise, the `FLAME.call` function calls will fail with a timeout even if the boot has not completed.

This PR sets the `:timeout` option to be the maximum between the `:timeout` and the `:boot_timeout`, to ensure that a timeout cannot happen before a boot_timeout happens.