### PR TITLE
Minor Fixes Found By Dialyzer

### DIFF
--- a/lib/flame/code_sync.ex
+++ b/lib/flame/code_sync.ex
@@ -193,7 +193,8 @@ defmodule FLAME.CodeSync do
           log_verbose("packaged size: #{File.stat!(out_path).size / (1024 * 1024)}mb")
         end
 
-        File.stream!(out_path, code.chunk_size, [])
+        # TODO: Change to File.stream!(out_path, code.chunk_size) once we require Elixir v1.16+
+        File.stream!(out_path, [], code.chunk_size)
       end
 
     %PackagedStream{

--- a/lib/flame/code_sync.ex
+++ b/lib/flame/code_sync.ex
@@ -193,7 +193,7 @@ defmodule FLAME.CodeSync do
           log_verbose("packaged size: #{File.stat!(out_path).size / (1024 * 1024)}mb")
         end
 
-        File.stream!(out_path, [], code.chunk_size)
+        File.stream!(out_path, code.chunk_size, [])
       end
 
     %PackagedStream{

--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -306,9 +306,6 @@ defmodule FLAME.Pool do
           if Keyword.fetch!(place_opts, :link), do: Process.link(child_pid)
           {:cancel, {:replace, [child_pid]}, result}
 
-        :ignore ->
-          {:cancel, :ok, :ignore}
-
         {:error, _reason} = result ->
           {:cancel, :ok, result}
       end

--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -363,9 +363,6 @@ defmodule FLAME.Runner do
         other when other in [{:ok, nil}, :error] -> {30_000, fn -> true end}
       end
 
-    timeout = opts[:timeout] || 30_000
-    boot_timeout = opts[:boot_timeout] || 30_000
-
     runner =
       %Runner{
         status: :awaiting_boot,
@@ -373,8 +370,8 @@ defmodule FLAME.Runner do
         backend_init: :pending,
         log: Keyword.get(opts, :log, false),
         single_use: Keyword.get(opts, :single_use, false),
-        timeout: max(timeout, boot_timeout),
-        boot_timeout: boot_timeout,
+        timeout: opts[:timeout] || 30_000,
+        boot_timeout: opts[:boot_timeout] || 30_000,
         shutdown_timeout: opts[:shutdown_timeout] || 30_000,
         idle_shutdown_after: idle_shutdown_after_ms,
         idle_shutdown_check: idle_check,

--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -363,6 +363,9 @@ defmodule FLAME.Runner do
         other when other in [{:ok, nil}, :error] -> {30_000, fn -> true end}
       end
 
+    timeout = opts[:timeout] || 30_000
+    boot_timeout = opts[:boot_timeout] || 30_000
+
     runner =
       %Runner{
         status: :awaiting_boot,
@@ -370,8 +373,8 @@ defmodule FLAME.Runner do
         backend_init: :pending,
         log: Keyword.get(opts, :log, false),
         single_use: Keyword.get(opts, :single_use, false),
-        timeout: opts[:timeout] || 30_000,
-        boot_timeout: opts[:boot_timeout] || 30_000,
+        timeout: max(timeout, boot_timeout),
+        boot_timeout: boot_timeout,
         shutdown_timeout: opts[:shutdown_timeout] || 30_000,
         idle_shutdown_after: idle_shutdown_after_ms,
         idle_shutdown_check: idle_check,


### PR DESCRIPTION
This solves a couple of minor fixes that were found by dialyzer as I was messing with #73.

1. The `File.stream!` call in code_sync.ex had its values out of order - the list of modes should be the last parameter of the call.
2. In `FLAME.Pool.place_child/3`, there was a match for an `:ignore` case coming back from `FLAME.Runner.place_child/3`. This case can't happen - `FLAME.Runner.place_child/3` calls out to `FLAME.Runner.call/4`, which will either exit, or return the value of the call to `FLAME.Runner.remote_call/5`, which can only return `{:ok, {result, pids}}` or `{:exit, reason}`.

This PR was branched out from my fork which also includes the change from #73, which is why the commit for setting the timeout is also included here.