### PR TITLE
Prevent work from being sent to unneeded runners

### DIFF
--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -40,7 +40,7 @@ defmodule FLAME.Pool do
   alias FLAME.{Pool, Runner, Queue, CodeSync}
   alias FLAME.Pool.{RunnerState, WaitingState, Caller}
 
-  @calling_sample_count 10
+  @calling_sample_count 3
   @default_max_concurrency 100
   @boot_timeout 30_000
   @idle_shutdown_after 30_000
@@ -529,7 +529,7 @@ defmodule FLAME.Pool do
   end
 
   defp needed_runners_count(state) do
-    Enum.max(state.calling_samples)
+    Enum.sum(state.calling_samples)
     |> div(state.max_concurrency)
     |> min(state.max)
     |> max(1)


### PR DESCRIPTION
Better allows for runners to be idled down after a spike of work has subsided, but while there is still some work being handled. The previous implementation sent work to the least-used runner, this keeps the pool unnecessarily large after a spike in work has subsided.