### PR TITLE
Set $callers in process dictionary

### DIFF
--- a/lib/flame/runner.ex
+++ b/lib/flame/runner.ex
@@ -122,9 +122,11 @@ defmodule FLAME.Runner do
     {ref, %Runner{} = runner, backend_state} = checkout(runner_pid)
     %Runner{terminator: terminator} = runner
     call_timeout = opts[:timeout] || runner.timeout
+    callers = [self() | Process.get(:"$callers", [])]
 
     result =
       remote_call(runner, backend_state, call_timeout, track_resources?, fn ->
+        Process.put(:"$callers", callers)
         if link?, do: Process.link(caller_pid)
         :ok = Terminator.deadline_me(terminator, call_timeout)
         if is_function(func, 1), do: func.(terminator), else: func.()

--- a/test/flame_test.exs
+++ b/test/flame_test.exs
@@ -256,6 +256,18 @@ defmodule FLAME.FLAMETest do
     end)
   end
 
+  @tag runner: [min: 1, max: 2, max_concurrency: 2, idle_shutdown_after: 500]
+  test "sets $callers", %{} = config do
+    parent = self()
+    assert FLAME.call(config.test, fn -> Process.get(:"$callers") end) == [parent]
+
+    FLAME.cast(config.test, fn ->
+      send(parent, {:callers, Process.get(:"$callers")})
+    end)
+
+    assert_receive {:callers, [_, ^parent]}
+  end
+
   describe "cast" do
     @tag runner: [min: 1, max: 2, max_concurrency: 2, idle_shutdown_after: 500]
     test "normal execution", %{} = config do


### PR DESCRIPTION
Fixes issues with ownership-tracked resources, such as with Ecto Sandbox and Req.Test.

See phoenixframework/flame#20.