### PR TITLE
Docs: Replace deprecated fly cli 'auth token' with 'tokens create'

### DIFF
--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -16,7 +16,7 @@ defmodule FLAME.FlyBackend do
   To set your `FLY_API_TOKEN` secret, you can run the following commands locally:
 
   ```bash
-  $ fly secrets set FLY_API_TOKEN="$(fly auth token)"
+  $ fly secrets set FLY_API_TOKEN="$(fly tokens create deploy -x 999999h)"
   ```
 
   The following backend options are supported, and mirror the

--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -16,7 +16,7 @@ defmodule FLAME.FlyBackend do
   To set your `FLY_API_TOKEN` secret, you can run the following commands locally:
 
   ```bash
-  $ fly secrets set FLY_API_TOKEN="$(fly tokens create deploy -x 999999h)"
+  $ fly secrets set FLY_API_TOKEN="$(fly tokens create deploy)"
   ```
 
   The following backend options are supported, and mirror the


### PR DESCRIPTION
https://fly.io/docs/security/tokens/
https://fly.io/docs/flyctl/tokens-create-deploy/

```
> fly auth token --help
DEPRECATED: Shows the authentication token that is currently in use by flyctl. The auth token used by flyctl may expire
quickly and shouldn't be used in places where the token needs to keep working for a long time. For API authentication,
you can use the "fly tokens create" command instead, to create narrowly-scoped tokens with a custom expiry.
```

```
fly tokens create deploy --help
Create an API token limited to managing a single app and its resources. Also available as TOKENS DEPLOY. Tokens are
valid for 20 years by default. We recommend using a shorter expiry if practical.

Usage:
  fly tokens create deploy [flags]

Flags:
  -a, --app string        Application name
  -c, --config string     Path to application configuration file
  -x, --expiry duration   The duration that the token will be valid (default 175200h0m0s)
  -h, --help              help for deploy
  -j, --json              JSON output
  -n, --name string       Token name (default "flyctl deploy token")
```