### PR TITLE
Fix OOM in Runner Node killing FLAME Pool

### DIFF
--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -497,7 +497,7 @@ defmodule FLAME.Pool do
         {:noreply, replace_caller(state, ref, caller_pid, child_pids)}
 
       reason when reason in [:ok, :timeout, :catch] ->
-        {:noreply, checkin_runner(state, ref, caller_pid, reason)}
+        {:noreply, checkin_runner(state, ref, caller_pid)}
     end
   end
 
@@ -570,21 +570,19 @@ defmodule FLAME.Pool do
     %{state | callers: new_callers}
   end
 
-  defp checkin_runner(state, ref, caller_pid, reason)
+  defp checkin_runner(state, ref, caller_pid)
        when is_reference(ref) and is_pid(caller_pid) do
     case state.callers do
       %{^caller_pid => %Caller{checkout_ref: ^ref} = caller} ->
         Process.demonitor(caller.monitor_ref, [:flush])
         drop_caller(state, caller_pid, caller)
 
-      # the only way to race a checkin is if the caller has expired while still in the
-      # waiting state and checks in on the timeout before we lease it a runner.
-      %{} when reason == :timeout ->
-        maybe_drop_waiting(state, caller_pid)
-
+      # A checkin can race an already-dropped caller. This is benign and must not
+      # crash the pool, which owns the named ETS meta table and whose death would
+      # cascade `lookup_meta/1` and `:noproc` failures to every other caller
+      # as shown in https://github.com/phoenixframework/flame/issues/66.
       %{} ->
-        raise ArgumentError,
-              "expected to checkin runner for #{inspect(caller_pid)} that does not exist"
+        maybe_drop_waiting(state, caller_pid)
     end
   end
 

--- a/test/flame_test.exs
+++ b/test/flame_test.exs
@@ -175,50 +175,6 @@ defmodule FLAME.FLAMETest do
     assert_receive {:DOWN, _ref, :process, ^active_checkout, :killed}
   end
 
-  @tag runner: [min: 1, max: 1, max_concurrency: 2]
-  test "runner OOM mid-call does not crash the pool", %{runner_sup: runner_sup} = config do
-    # Reproduces the runner OOM race from
-    # https://github.com/phoenixframework/flame/issues/66.
-    #
-    # A caller is processing for 500ms when its runner node dies (simulated by a
-    # brutal_kill 100ms in). The pool sees the runner `:DOWN` and drops+kills the
-    # caller in `drop_child_runner/2`. Meanwhile the caller's own `Runner.call`
-    # exit sends a late `:catch` cancel for a caller the pool no longer tracks.
-    # The pool must survive that stray checkin rather than crashing and taking its
-    # ETS meta table (and every other in-flight caller) down with it.
-    ExUnit.CaptureLog.capture_log(fn ->
-      # the real pool GenServer, registered under the pool name. The
-      # `start_supervised!` pid is the pool *supervisor*, which would silently
-      # restart the pool and mask the crash, so we monitor the GenServer directly.
-      pool = Process.whereis(config.test)
-      pool_ref = Process.monitor(pool)
-
-      # fake 500ms of processing on the runner
-      {:ok, caller} = sim_long_running(config.test, 500)
-      Process.unlink(caller)
-      caller_ref = Process.monitor(caller)
-
-      assert [{:undefined, runner, :worker, [FLAME.Runner]}] =
-               Supervisor.which_children(runner_sup)
-
-      # simulate the OOM 100ms into processing
-      Process.sleep(100)
-      Process.exit(runner, :brutal_kill)
-
-      # the pool drops and kills the caller from the runner `:DOWN` first, which
-      # guarantees the caller is no longer tracked once the stray cancel arrives
-      assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}, 1000
-
-      # ...then the caller's in-flight `:catch` cancel lands for the now-unknown caller
-      send(pool, {:cancel, make_ref(), caller, :catch})
-
-      # the pool must stay up (same pid) and keep serving work
-      refute_receive {:DOWN, ^pool_ref, :process, ^pool, _}, 500
-      assert Process.alive?(pool)
-      assert FLAME.call(config.test, fn -> :works end) == :works
-    end)
-  end
-
   @tag runner: [min: 0, max: 1, max_concurrency: 2, idle_shutdown_after: 50]
   test "call links", %{runner_sup: runner_sup} = config do
     ExUnit.CaptureLog.capture_log(fn ->
@@ -684,5 +640,37 @@ defmodule FLAME.FLAMETest do
     assert FLAME.call(config.test, fn -> :works end) == :works
     Supervisor.stop(pool_pid)
     refute File.exists?(artifact)
+  end
+
+  # Reproduces the runner OOM race from https://github.com/phoenixframework/flame/issues/66.
+  @tag runner: [min: 1, max: 1, max_concurrency: 2]
+  test "runner OOM mid-call does not crash the pool", %{runner_sup: runner_sup} = config do
+    ExUnit.CaptureLog.capture_log(fn ->
+      pool = Process.whereis(config.test)
+      pool_ref = Process.monitor(pool)
+
+      {:ok, caller} = sim_long_running(config.test, 500)
+      Process.unlink(caller)
+      caller_ref = Process.monitor(caller)
+
+      assert [{:undefined, runner, :worker, [FLAME.Runner]}] =
+               Supervisor.which_children(runner_sup)
+
+      # simulate the OOM 100ms into processing
+      Process.sleep(100)
+      Process.exit(runner, :brutal_kill)
+
+      # the pool drops and kills the caller from the runner `:DOWN` first, which
+      # guarantees the caller is no longer tracked once the stray cancel arrives
+      assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}, 1000
+
+      # ...then the caller's in-flight `:catch` cancel lands for the now-unknown caller
+      send(pool, {:cancel, make_ref(), caller, :catch})
+
+      # the pool must stay up (same pid) and keep serving work
+      refute_receive {:DOWN, ^pool_ref, :process, ^pool, _}, 500
+      assert Process.alive?(pool)
+      assert FLAME.call(config.test, fn -> :works end) == :works
+    end)
   end
 end

--- a/test/flame_test.exs
+++ b/test/flame_test.exs
@@ -175,6 +175,50 @@ defmodule FLAME.FLAMETest do
     assert_receive {:DOWN, _ref, :process, ^active_checkout, :killed}
   end
 
+  @tag runner: [min: 1, max: 1, max_concurrency: 2]
+  test "runner OOM mid-call does not crash the pool", %{runner_sup: runner_sup} = config do
+    # Reproduces the runner OOM race from
+    # https://github.com/phoenixframework/flame/issues/66.
+    #
+    # A caller is processing for 500ms when its runner node dies (simulated by a
+    # brutal_kill 100ms in). The pool sees the runner `:DOWN` and drops+kills the
+    # caller in `drop_child_runner/2`. Meanwhile the caller's own `Runner.call`
+    # exit sends a late `:catch` cancel for a caller the pool no longer tracks.
+    # The pool must survive that stray checkin rather than crashing and taking its
+    # ETS meta table (and every other in-flight caller) down with it.
+    ExUnit.CaptureLog.capture_log(fn ->
+      # the real pool GenServer, registered under the pool name. The
+      # `start_supervised!` pid is the pool *supervisor*, which would silently
+      # restart the pool and mask the crash, so we monitor the GenServer directly.
+      pool = Process.whereis(config.test)
+      pool_ref = Process.monitor(pool)
+
+      # fake 500ms of processing on the runner
+      {:ok, caller} = sim_long_running(config.test, 500)
+      Process.unlink(caller)
+      caller_ref = Process.monitor(caller)
+
+      assert [{:undefined, runner, :worker, [FLAME.Runner]}] =
+               Supervisor.which_children(runner_sup)
+
+      # simulate the OOM 100ms into processing
+      Process.sleep(100)
+      Process.exit(runner, :brutal_kill)
+
+      # the pool drops and kills the caller from the runner `:DOWN` first, which
+      # guarantees the caller is no longer tracked once the stray cancel arrives
+      assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}, 1000
+
+      # ...then the caller's in-flight `:catch` cancel lands for the now-unknown caller
+      send(pool, {:cancel, make_ref(), caller, :catch})
+
+      # the pool must stay up (same pid) and keep serving work
+      refute_receive {:DOWN, ^pool_ref, :process, ^pool, _}, 500
+      assert Process.alive?(pool)
+      assert FLAME.call(config.test, fn -> :works end) == :works
+    end)
+  end
+
   @tag runner: [min: 0, max: 1, max_concurrency: 2, idle_shutdown_after: 50]
   test "call links", %{runner_sup: runner_sup} = config do
     ExUnit.CaptureLog.capture_log(fn ->


### PR DESCRIPTION
First reported in https://github.com/phoenixframework/flame/issues/66.

I have also encountered this error when testing my [DinD backend for FLAME](https://github.com/Lakret/flame-docker-backend) in one of my apps.

After further investigation, it seems that the issue is due to a race condition in `FLAME.Pool.checkin_runner/4`: if the caller is already dropped with the `reason == :catch`, the Pool process crashes with `ArgumentError`, which leads to the :ets table being absent for the following calls. Instead of crashing, this fix just executes `maybe_drop_waiting/2` irrespective of the reason.

P.S. After fixing this issue, I noticed another issue: apparently FLAME Runner node going down can cause all other Runner nodes disconnecting due to [prevent_overlapping_partitions](https://www.erlang.org/doc/apps/kernel/kernel_app.html#prevent_overlapping_partitions) logic in the :global module. It's outside the scope of this PR, but if you are encountering this issue, there are two ways to fix it:

- disable this :global behavior via `-kernel prevent_overlapping_partitions false` in `rel/vm.args.eex` (if you are using releases to deploy)
- make FLAME Runner nodes hidden (didn't test that one yet).

Overall, after testing the changes in this PR in my app, the original problem is solved - Pool doesn't crash on Runner's OOMs anymore.