### PR TITLE
Increase SSL depth to 5 for Let's Encrypt Gen Y chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,67 @@
-# FLAME (NomixGroup fork)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/phoenixframework/flame/elixir.yml)](https://github.com/phoenixframework/flame/actions/workflows/elixir.yml) [![Hex.pm](https://img.shields.io/hexpm/v/flame.svg)](https://hex.pm/packages/flame) [![Documentation](https://img.shields.io/badge/documentation-gray)](https://hexdocs.pm/flame)
 
-Temporary fork of [phoenixframework/flame](https://github.com/phoenixframework/flame).
+Imagine if we could auto scale simply by wrapping any existing app code in a function and have that block of code run in a temporary copy of the app.
 
-## Change
+Enter the FLAME pattern.
 
-Increased TLS certificate chain depth from 2 to 5 in `lib/flame/fly_backend.ex`.
+> FLAME - Fleeting Lambda Application for Modular Execution
 
-**Why:** Let's Encrypt moved `api.machines.dev` to their Generation Y hierarchy on
-2026-07-26, which adds a cross-signed root making the chain 3 CAs deep.
-FLAME's hardcoded `depth: 2` is one hop too shallow, causing all FLAME worker
-boots to fail with `{bad_cert, max_path_length_reached}`.
+With FLAME, you treat your *entire application* as a lambda, where modular parts can be executed on short-lived infrastructure.
 
-See: https://github.com/phoenixframework/flame/issues/88
+Check the screencast to see it in action:
 
-## Usage
+[![Video](https://img.youtube.com/vi/l1xt_rkWdic/maxresdefault.jpg)](https://www.youtube.com/watch?v=l1xt_rkWdic)
 
-In `mix.exs`:
+## Setup
 
-    {:flame, github: "NomixGroup/flame", branch: "main", override: true}
+First add `:flame` as a dependency:
 
-## Revert
+```elixir
+defp deps do
+  [
+    # For Erlang/OTP 26 and earlier, you also need Jason
+    # {:jason, ">= 0.0.0"},
+    {:flame, "~> 0.5"}
+  ]
+end
+```
 
-Once a fix ships on hex.pm, revert `mix.exs` to `{:flame, "~> 0.5"}` and
-delete this fork.
+Then start a FLAME pool in your supervision tree, typically on `application.ex`. The example below uses [Fly.io](https://fly.io/)'s backend:
+
+```elixir
+children = [
+  {FLAME.Pool,
+   name: MyApp.SamplePool,
+   backend: FLAME.FlyBackend,
+   min: 0,
+   max: 10,
+   max_concurrency: 5,
+   idle_shutdown_after: 30_000,
+   log: :debug}
+]
+```
+
+Now you can wrap any block of code in a `FLAME.call` and it will find or boot a copy of the app, execute the work there, and return the results:
+
+```elixir
+def generate_thumbnails(%Video{} = vid, interval) do
+  FLAME.call(MyApp.FFMpegRunner, fn ->
+    # I'm runner on a short-lived, temporary server
+    tmp_dir = Path.join(System.tmp_dir!(), Ecto.UUID.generate())
+    File.mkdir!(tmp_dir)
+    System.cmd("ffmpeg", ~w(-i #{vid.url} -vf fps=1/#{interval} #{tmp_dir}/%02d.png))
+    urls = VideoStore.put_thumbnails(vid, Path.wildcard(tmp_dir <> "/*.png"))
+    Repo.insert_all(Thumbnail, Enum.map(urls, &%{video_id: vid.id, url: &1}))
+  end)
+end
+```
+
+Here we wrapped up our CPU expensive `ffmpeg` operation in a `FLAME.call/2`. FLAME accepts a function and any variables that the function closes over. In this example, the `%Video{}` struct and `interval` are passed along automatically. The work happens in a temporary copy of the app. We can do any work inside the FLAME call because we are running the *entire application*, database connection(s) and all.
+
+`FLAME` provides the following interfaces for elastically scaled operations:
+
+  * `FLAME.call/3` - used for synchronous calls
+  * `FLAME.cast/3` - used for async casts where you don't need to wait on the results
+  * `FLAME.place_child/3` – used for placing a child spec somewhere to run, in place of `DynamicSupervisor.start_child`, `Task.Supervisor.start_child`, etc
+
+The `FLAME.Pool` handles elastically scaling runners up and down, as well as remote monitoring of resources. Check the moduledoc for example usage.

--- a/README.md
+++ b/README.md
@@ -1,67 +1,25 @@
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/phoenixframework/flame/elixir.yml)](https://github.com/phoenixframework/flame/actions/workflows/elixir.yml) [![Hex.pm](https://img.shields.io/hexpm/v/flame.svg)](https://hex.pm/packages/flame) [![Documentation](https://img.shields.io/badge/documentation-gray)](https://hexdocs.pm/flame)
+# FLAME (NomixGroup fork)
 
-Imagine if we could auto scale simply by wrapping any existing app code in a function and have that block of code run in a temporary copy of the app.
+Temporary fork of [phoenixframework/flame](https://github.com/phoenixframework/flame).
 
-Enter the FLAME pattern.
+## Change
 
-> FLAME - Fleeting Lambda Application for Modular Execution
+Increased TLS certificate chain depth from 2 to 5 in `lib/flame/fly_backend.ex`.
 
-With FLAME, you treat your *entire application* as a lambda, where modular parts can be executed on short-lived infrastructure.
+**Why:** Let's Encrypt moved `api.machines.dev` to their Generation Y hierarchy on
+2026-07-26, which adds a cross-signed root making the chain 3 CAs deep.
+FLAME's hardcoded `depth: 2` is one hop too shallow, causing all FLAME worker
+boots to fail with `{bad_cert, max_path_length_reached}`.
 
-Check the screencast to see it in action:
+See: https://github.com/phoenixframework/flame/issues/88
 
-[![Video](https://img.youtube.com/vi/l1xt_rkWdic/maxresdefault.jpg)](https://www.youtube.com/watch?v=l1xt_rkWdic)
+## Usage
 
-## Setup
+In `mix.exs`:
 
-First add `:flame` as a dependency:
+    {:flame, github: "NomixGroup/flame", branch: "main", override: true}
 
-```elixir
-defp deps do
-  [
-    # For Erlang/OTP 26 and earlier, you also need Jason
-    # {:jason, ">= 0.0.0"},
-    {:flame, "~> 0.5"}
-  ]
-end
-```
+## Revert
 
-Then start a FLAME pool in your supervision tree, typically on `application.ex`. The example below uses [Fly.io](https://fly.io/)'s backend:
-
-```elixir
-children = [
-  {FLAME.Pool,
-   name: MyApp.SamplePool,
-   backend: FLAME.FlyBackend,
-   min: 0,
-   max: 10,
-   max_concurrency: 5,
-   idle_shutdown_after: 30_000,
-   log: :debug}
-]
-```
-
-Now you can wrap any block of code in a `FLAME.call` and it will find or boot a copy of the app, execute the work there, and return the results:
-
-```elixir
-def generate_thumbnails(%Video{} = vid, interval) do
-  FLAME.call(MyApp.FFMpegRunner, fn ->
-    # I'm runner on a short-lived, temporary server
-    tmp_dir = Path.join(System.tmp_dir!(), Ecto.UUID.generate())
-    File.mkdir!(tmp_dir)
-    System.cmd("ffmpeg", ~w(-i #{vid.url} -vf fps=1/#{interval} #{tmp_dir}/%02d.png))
-    urls = VideoStore.put_thumbnails(vid, Path.wildcard(tmp_dir <> "/*.png"))
-    Repo.insert_all(Thumbnail, Enum.map(urls, &%{video_id: vid.id, url: &1}))
-  end)
-end
-```
-
-Here we wrapped up our CPU expensive `ffmpeg` operation in a `FLAME.call/2`. FLAME accepts a function and any variables that the function closes over. In this example, the `%Video{}` struct and `interval` are passed along automatically. The work happens in a temporary copy of the app. We can do any work inside the FLAME call because we are running the *entire application*, database connection(s) and all.
-
-`FLAME` provides the following interfaces for elastically scaled operations:
-
-  * `FLAME.call/3` - used for synchronous calls
-  * `FLAME.cast/3` - used for async casts where you don't need to wait on the results
-  * `FLAME.place_child/3` – used for placing a child spec somewhere to run, in place of `DynamicSupervisor.start_child`, `Task.Supervisor.start_child`, etc
-
-The `FLAME.Pool` handles elastically scaling runners up and down, as well as remote monitoring of resources. Check the moduledoc for example usage.
+Once a fix ships on hex.pm, revert `mix.exs` to `{:flame, "~> 0.5"}` and
+delete this fork.

--- a/lib/flame/fly_backend.ex
+++ b/lib/flame/fly_backend.ex
@@ -349,7 +349,7 @@ defmodule FLAME.FlyBackend do
       ssl:
         [
           verify: :verify_peer,
-          depth: 2,
+          depth: 5,
           customize_hostname_check: [
             match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
           ]


### PR DESCRIPTION
FLAME.FlyBackend has a hardcoded depth of 2 in the SSL config, which is one hop too shallow for the new Let's Encrypt Generation Y chain on api.machines.dev (renewed 2026-07-26).

This is currently causing all FLAME worker boots to fail with bad_cert/max_path_length_reached.